### PR TITLE
firebase eventId is linked to event after creation

### DIFF
--- a/frontend/app/components/Map.jsx
+++ b/frontend/app/components/Map.jsx
@@ -94,6 +94,7 @@ export default function Map() {
           (await response.json()).error || "Failed to create event"
         );
 
+      const response_data = await response.json();
       setMarkers((prev) => [
         ...prev,
         {
@@ -101,6 +102,7 @@ export default function Map() {
           lng: selectedLocation.lng,
           ...formData,
           host: user.email,
+          eventId: response_data.eventId
         },
       ]);
 
@@ -164,6 +166,7 @@ export default function Map() {
       }
     }
   };
+
 
   return (
     <div className="h-screen flex flex-col bg-gray-50">


### PR DESCRIPTION
Firebase ID wasn't linked to event previously. Now after creation of event of frontend and confirmed creation on database, the id of the event in the database is linked to the event.