### PR TITLE
fixed edit button changing location to center of map

### DIFF
--- a/frontend/app/components/Map.jsx
+++ b/frontend/app/components/Map.jsx
@@ -382,10 +382,9 @@ export default function Map() {
   };
 
   const handleEditButtonClick = () => {
-    setShowEditForm(true);
-    if (mapRef.current) {
-      const center = mapRef.current.getCenter();
-      updateFormLocation(center.lat(), center.lng());
+    if (selectedEvent) {
+      updateFormLocation(selectedEvent.lat, selectedEvent.lng);
+      setShowEditForm(true);
     }
   };
 


### PR DESCRIPTION
Pulled from main and the edit button changed the location of the event when I clicked the button.
This should fix it